### PR TITLE
fix: [PhU-113] Fixing outdated imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,4 +15,5 @@ Unreleased
 Fixed
 =====
 
+* Fixing outdated imports `PhU-113 <https://youtrack.raccoongang.com/issue/PhU-113>`_
 * Adopt AudioXBlock for the Quince release `PhU-113 <https://youtrack.raccoongang.com/issue/PhU-113>`_

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -9,7 +9,7 @@ from xmodule.fields import RelativeTime
 
 from xblock.core import XBlock
 from xblock.fields import Scope, Integer, String, Integer, Boolean
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from webob.multidict import MultiDict
 from webob import Response
 from mimetypes import MimeTypes


### PR DESCRIPTION
### Description

This MR is opened to fix an error with an incorrect import:

```
2024-04-25 16:06:20,053 WARNING 56 [xblock.plugin] [user None] [ip None] plugin.py:144 - Unable to load XBlock 'audio'
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/xblock/plugin.py", line 141, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/openedx/venv/lib/python3.8/site-packages/xblock/plugin.py", line 70, in _load_class_entry_point
    class_ = entry_point.load()
  File "/openedx/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2518, in load
    return self.resolve()
  File "/openedx/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2524, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/openedx/venv/src/audio-xblock/audio/__init__.py", line 1, in <module>
    from .audio import AudioXBlock
  File "/openedx/venv/src/audio-xblock/audio/audio.py", line 12, in <module>
    from xblock.fragment import Fragment
ModuleNotFoundError: No module named 'xblock.fragment'
```

YT:
- https://youtrack.raccoongang.com/issue/PhU-113/Audio-block-Adopt-for-the-Quince-release